### PR TITLE
Add detail links for anime cards

### DIFF
--- a/anime.html
+++ b/anime.html
@@ -253,6 +253,14 @@
                 </div>
               </div>
             </a>
+            <a href="anime-detail.html?id=demon-slayer-infinity-preview" data-id="demon-slayer-infinity-preview">
+              <div class="anime-card">
+                <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+                <div class="anime-content">
+                  <h3 class="anime-title">귀멸의 칼날: 무한성 예고편 분석</h3>
+                </div>
+              </div>
+            </a>
           </div>
         </section>
         
@@ -271,14 +279,30 @@
                   </div>
                 </div>
               </a>
-              <a href="anime-detail.html?id=haikyuu-series-best-songs" data-id="haikyuu-series-best-songs">
-                <div class="anime-card">
-                  <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-                  <div class="anime-content">
-                    <h3 class="anime-title">하이큐!! 시리즈 전체 명곡 정리</h3>
-                  </div>
+            <a href="anime-detail.html?id=haikyuu-series-best-songs" data-id="haikyuu-series-best-songs">
+              <div class="anime-card">
+                <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+                <div class="anime-content">
+                  <h3 class="anime-title">하이큐!! 시리즈 전체 명곡 정리</h3>
                 </div>
-              </a>
+              </div>
+            </a>
+            <a href="anime-detail.html?id=chainsaw-man-best-ost" data-id="chainsaw-man-best-ost">
+              <div class="anime-card">
+                <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+                <div class="anime-content">
+                  <h3 class="anime-title">체인소 맨 베스트 OST</h3>
+                </div>
+              </div>
+            </a>
+            <a href="anime-detail.html?id=demon-slayer-popular-ost" data-id="demon-slayer-popular-ost">
+              <div class="anime-card">
+                <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+                <div class="anime-content">
+                  <h3 class="anime-title">귀멸의 칼날 인기 OST</h3>
+                </div>
+              </div>
+            </a>
           </div>
         </section>
         

--- a/anime.html
+++ b/anime.html
@@ -58,11 +58,7 @@
     <!-- 하부 게시판 메뉴 - 굿즈 정보 제거, 세부검색 추가 -->
     <div class="submenu">
       <a href="#" class="active">전체글</a>
-      <a href="#">작품리뷰</a>
       <a href="#">게시판</a>
-      <a href="#">캐릭터</a>
-      <a href="#">음악/OST</a>
-      <a href="#">성우</a>
       <a href="#">제작사</a>
       <a href="#" class="search-menu-item">세부검색</a>
     </div>
@@ -89,114 +85,138 @@
       <!-- 이미지 스타일 애니메이션 그리드로 변경 -->
       <div class="anime-grid weekday-anime">
         <!-- 월요일 방영 (신작) -->
-        <div class="anime-card" data-day="mon">
-          <span class="new-badge">신</span>
-          <div class="weekday-badge">월</div>
-          <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-          <div class="anime-content">
-            <h3 class="anime-title">마법소녀 카피캣</h3>
+        <a href="anime-detail.html?id=magical-girl-copycat" data-id="magical-girl-copycat">
+          <div class="anime-card" data-day="mon">
+            <span class="new-badge">신</span>
+            <div class="weekday-badge">월</div>
+            <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+            <div class="anime-content">
+              <h3 class="anime-title">마법소녀 카피캣</h3>
+            </div>
           </div>
-        </div>
+        </a>
         
         <!-- 화요일 방영 -->
-        <div class="anime-card" data-day="tue">
-          <div class="weekday-badge">화</div>
-          <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-          <div class="anime-content">
-            <h3 class="anime-title">빌런 입학하기</h3>
+        <a href="anime-detail.html?id=villain-admission" data-id="villain-admission">
+          <div class="anime-card" data-day="tue">
+            <div class="weekday-badge">화</div>
+            <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+            <div class="anime-content">
+              <h3 class="anime-title">빌런 입학하기</h3>
+            </div>
           </div>
-        </div>
+        </a>
         
         <!-- 수요일 방영 (신작) -->
-        <div class="anime-card" data-day="wed">
-          <span class="new-badge">신</span>
-          <div class="weekday-badge">수</div>
-          <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-          <div class="anime-content">
-            <h3 class="anime-title">소드 아트 온라인: 유니탈 링</h3>
+        <a href="anime-detail.html?id=sao-unital-ring" data-id="sao-unital-ring">
+          <div class="anime-card" data-day="wed">
+            <span class="new-badge">신</span>
+            <div class="weekday-badge">수</div>
+            <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+            <div class="anime-content">
+              <h3 class="anime-title">소드 아트 온라인: 유니탈 링</h3>
+            </div>
           </div>
-        </div>
+        </a>
         
         <!-- 수요일 방영 2 -->
-        <div class="anime-card" data-day="wed">
-          <div class="weekday-badge">수</div>
-          <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-          <div class="anime-content">
-            <h3 class="anime-title">도쿄 리벤저스: 결말편</h3>
+        <a href="anime-detail.html?id=tokyo-revengers-finale" data-id="tokyo-revengers-finale">
+          <div class="anime-card" data-day="wed">
+            <div class="weekday-badge">수</div>
+            <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+            <div class="anime-content">
+              <h3 class="anime-title">도쿄 리벤저스: 결말편</h3>
+            </div>
           </div>
-        </div>
+        </a>
         
         <!-- 목요일 방영 -->
-        <div class="anime-card" data-day="thu">
-          <div class="weekday-badge">목</div>
-          <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-          <div class="anime-content">
-            <h3 class="anime-title">블루 록 2기</h3>
+        <a href="anime-detail.html?id=blue-lock-season-2" data-id="blue-lock-season-2">
+          <div class="anime-card" data-day="thu">
+            <div class="weekday-badge">목</div>
+            <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+            <div class="anime-content">
+              <h3 class="anime-title">블루 록 2기</h3>
+            </div>
           </div>
-        </div>
+        </a>
         
         <!-- 금요일 방영 (신작) -->
-        <div class="anime-card" data-day="fri">
-          <span class="new-badge">신</span>
-          <div class="weekday-badge">금</div>
-          <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-          <div class="anime-content">
-            <h3 class="anime-title">하이큐!! 최종시즌</h3>
+        <a href="anime-detail.html?id=haikyuu-final" data-id="haikyuu-final">
+          <div class="anime-card" data-day="fri">
+            <span class="new-badge">신</span>
+            <div class="weekday-badge">금</div>
+            <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+            <div class="anime-content">
+              <h3 class="anime-title">하이큐!! 최종시즌</h3>
+            </div>
           </div>
-        </div>
+        </a>
         
         <!-- 토요일 방영 -->
-        <div class="anime-card" data-day="sat">
-          <div class="weekday-badge">토</div>
-          <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-          <div class="anime-content">
-            <h3 class="anime-title">체인소 맨 2부</h3>
+        <a href="anime-detail.html?id=chainsaw-man-2" data-id="chainsaw-man-2">
+          <div class="anime-card" data-day="sat">
+            <div class="weekday-badge">토</div>
+            <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+            <div class="anime-content">
+              <h3 class="anime-title">체인소 맨 2부</h3>
+            </div>
           </div>
-        </div>
+        </a>
         
         <!-- 토요일 방영 2 -->
-        <div class="anime-card" data-day="sat">
-          <div class="weekday-badge">토</div>
-          <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-          <div class="anime-content">
-            <h3 class="anime-title">귀멸의 칼날: 무한성</h3>
+        <a href="anime-detail.html?id=demon-slayer-infinity" data-id="demon-slayer-infinity">
+          <div class="anime-card" data-day="sat">
+            <div class="weekday-badge">토</div>
+            <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+            <div class="anime-content">
+              <h3 class="anime-title">귀멸의 칼날: 무한성</h3>
+            </div>
           </div>
-        </div>
+        </a>
         
         <!-- 일요일 방영 -->
-        <div class="anime-card" data-day="sun">
-          <div class="weekday-badge">일</div>
-          <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-          <div class="anime-content">
-            <h3 class="anime-title">원피스 리마스터</h3>
+        <a href="anime-detail.html?id=one-piece-remaster" data-id="one-piece-remaster">
+          <div class="anime-card" data-day="sun">
+            <div class="weekday-badge">일</div>
+            <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+            <div class="anime-content">
+              <h3 class="anime-title">원피스 리마스터</h3>
+            </div>
           </div>
-        </div>
+        </a>
         
         <!-- 추가 애니메이션 카드 (10개 이상으로 늘림) -->
-        <div class="anime-card" data-day="mon">
-          <div class="weekday-badge">월</div>
-          <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-          <div class="anime-content">
-            <h3 class="anime-title">나의 히어로 아카데미아 외전</h3>
+        <a href="anime-detail.html?id=my-hero-academia-gaiden" data-id="my-hero-academia-gaiden">
+          <div class="anime-card" data-day="mon">
+            <div class="weekday-badge">월</div>
+            <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+            <div class="anime-content">
+              <h3 class="anime-title">나의 히어로 아카데미아 외전</h3>
+            </div>
           </div>
-        </div>
+        </a>
         
-        <div class="anime-card" data-day="tue">
-          <span class="new-badge">신</span>
-          <div class="weekday-badge">화</div>
-          <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-          <div class="anime-content">
-            <h3 class="anime-title">내 눈에만 보이는 헌터길드</h3>
+        <a href="anime-detail.html?id=invisible-hunter-guild" data-id="invisible-hunter-guild">
+          <div class="anime-card" data-day="tue">
+            <span class="new-badge">신</span>
+            <div class="weekday-badge">화</div>
+            <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+            <div class="anime-content">
+              <h3 class="anime-title">내 눈에만 보이는 헌터길드</h3>
+            </div>
           </div>
-        </div>
+        </a>
         
-        <div class="anime-card" data-day="wed">
-          <div class="weekday-badge">수</div>
-          <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-          <div class="anime-content">
-            <h3 class="anime-title">불꽃 소방대</h3>
+        <a href="anime-detail.html?id=fire-force" data-id="fire-force">
+          <div class="anime-card" data-day="wed">
+            <div class="weekday-badge">수</div>
+            <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+            <div class="anime-content">
+              <h3 class="anime-title">불꽃 소방대</h3>
+            </div>
           </div>
-        </div>
+        </a>
       </div>
     </section>
     
@@ -209,24 +229,30 @@
             <a href="#" class="view-more">더보기</a>
           </div>
           <div class="anime-grid small">
-            <div class="anime-card">
-              <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-              <div class="anime-content">
-                <h3 class="anime-title">하이큐!! 최종시즌 1화 - 결전의 서막</h3>
+            <a href="anime-detail.html?id=haikyuu-final-ep1" data-id="haikyuu-final-ep1">
+              <div class="anime-card">
+                <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+                <div class="anime-content">
+                  <h3 class="anime-title">하이큐!! 최종시즌 1화 - 결전의 서막</h3>
+                </div>
               </div>
-            </div>
-            <div class="anime-card">
-              <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-              <div class="anime-content">
-                <h3 class="anime-title">체인소 맨 2부 - 전작과 비교 분석</h3>
+            </a>
+            <a href="anime-detail.html?id=chainsaw-man-2-analysis" data-id="chainsaw-man-2-analysis">
+              <div class="anime-card">
+                <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+                <div class="anime-content">
+                  <h3 class="anime-title">체인소 맨 2부 - 전작과 비교 분석</h3>
+                </div>
               </div>
-            </div>
-            <div class="anime-card">
-              <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-              <div class="anime-content">
-                <h3 class="anime-title">소드 아트 온라인: 유니탈 링 세계관</h3>
+            </a>
+            <a href="anime-detail.html?id=sao-unital-ring-world" data-id="sao-unital-ring-world">
+              <div class="anime-card">
+                <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+                <div class="anime-content">
+                  <h3 class="anime-title">소드 아트 온라인: 유니탈 링 세계관</h3>
+                </div>
               </div>
-            </div>
+            </a>
           </div>
         </section>
         
@@ -237,18 +263,22 @@
             <a href="#" class="view-more">더보기</a>
           </div>
           <div class="anime-grid small">
-            <div class="anime-card">
-              <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-              <div class="anime-content">
-                <h3 class="anime-title">2025년 2분기 애니 OP/ED 모음</h3>
-              </div>
-            </div>
-            <div class="anime-card">
-              <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
-              <div class="anime-content">
-                <h3 class="anime-title">하이큐!! 시리즈 전체 명곡 정리</h3>
-              </div>
-            </div>
+              <a href="anime-detail.html?id=2025-q2-op-ed" data-id="2025-q2-op-ed">
+                <div class="anime-card">
+                  <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+                  <div class="anime-content">
+                    <h3 class="anime-title">2025년 2분기 애니 OP/ED 모음</h3>
+                  </div>
+                </div>
+              </a>
+              <a href="anime-detail.html?id=haikyuu-series-best-songs" data-id="haikyuu-series-best-songs">
+                <div class="anime-card">
+                  <div class="anime-image" style="background-image: url('https://via.placeholder.com/400x533');"></div>
+                  <div class="anime-content">
+                    <h3 class="anime-title">하이큐!! 시리즈 전체 명곡 정리</h3>
+                  </div>
+                </div>
+              </a>
           </div>
         </section>
         


### PR DESCRIPTION
## Summary
- wrap all `.anime-card` elements with anchor tags so each card links to its detail page
- remove unused submenu items

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68415b76166c832b86808238e041d84e